### PR TITLE
Distributed Robot Runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ examples/ros/__pycache__/*
 */.DS_Store
 .DS_Store
 .vscode
+configs/RobotRunnerConfig-99cb2678-3ec7-11ef-b996-27f6b2451caf.py

--- a/experiments/distributed_client/rr_client.py
+++ b/experiments/distributed_client/rr_client.py
@@ -1,0 +1,23 @@
+import asyncio
+from ExperimentOrchestrator.Architecture.Distributed.RRWebSocketClient import RRWebSocketClient
+
+class RRClient(RRWebSocketClient):
+    
+    # overrides before_experiment from abstract class
+    def remote_method():
+        print('Running before experiment remotelly!')
+
+        # Your code here
+
+async def main():
+    server_address = "ws://server.robot-runner:8765"
+    client_id = "c1"
+    client = RRClient(server_address, client_id)
+    await client.register()
+
+try:
+    loop = asyncio.get_running_loop()
+except RuntimeError:
+    asyncio.run(main())
+else:
+    loop.create_task(main())

--- a/experiments/mini_test/mini_test_config.py
+++ b/experiments/mini_test/mini_test_config.py
@@ -26,6 +26,8 @@ class RobotRunnerConfig:
     # Path to store results at
     # NOTE: Path does not need to exist, will be appended with 'name' as specified in this config and created on runtime
     results_output_path:        Path             = Path("~/Documents/experiments")
+    # Number of clients: the orchestrator only starts once all the clients connect. For standalone, use None as value.
+    distributed_clients:        int             = None
     # =================================================USER SPECIFIC UNNECESSARY CONFIG===============================================
 
     # Dynamic configurations can be one-time satisfied here before the program takes the config as-is

--- a/robot-runner/ConfigValidator/Config/RobotRunnerConfig.py
+++ b/robot-runner/ConfigValidator/Config/RobotRunnerConfig.py
@@ -25,6 +25,9 @@ class RobotRunnerConfig:
     # Path to store results at
     # NOTE: Path does not need to exist, will be appended with 'name' as specified in this config and created on runtime
     results_output_path:        Path             = Path("~/Documents/experiments")
+    # Distributed RR
+    # NOTE: For standalone mode, set distributed_clients to None.
+    distributed_clients:        int              = None
     # =================================================USER SPECIFIC UNNECESSARY CONFIG===============================================
 
     # Dynamic configurations can be one-time satisfied here before the program takes the config as-is
@@ -32,16 +35,30 @@ class RobotRunnerConfig:
     def __init__(self):
         """Executes immediately after program start, on config load"""
 
-        EventSubscriptionController.subscribe_to_multiple_events([ 
-            (RobotRunnerEvents.BEFORE_EXPERIMENT,   self.before_experiment), 
-            (RobotRunnerEvents.BEFORE_RUN,          self.before_run),
-            (RobotRunnerEvents.START_RUN,           self.start_run),
-            (RobotRunnerEvents.START_MEASUREMENT,   self.start_measurement),
-            (RobotRunnerEvents.LAUNCH_MISSION,      self.launch_mission),
-            (RobotRunnerEvents.STOP_MEASUREMENT,    self.stop_measurement),
-            (RobotRunnerEvents.STOP_RUN,            self.stop_run),
-            (RobotRunnerEvents.POPULATE_RUN_DATA,   self.populate_run_data),
-            (RobotRunnerEvents.AFTER_EXPERIMENT,    self.after_experiment)
+        # EventSubscriptionController.subscribe_to_multiple_events([ 
+        #     (RobotRunnerEvents.BEFORE_EXPERIMENT,   self.before_experiment), 
+        #     (RobotRunnerEvents.BEFORE_RUN,          self.before_run),
+        #     (RobotRunnerEvents.START_RUN,           self.start_run),
+        #     (RobotRunnerEvents.START_MEASUREMENT,   self.start_measurement),
+        #     (RobotRunnerEvents.LAUNCH_MISSION,      self.launch_mission),
+        #     (RobotRunnerEvents.STOP_MEASUREMENT,    self.stop_measurement),
+        #     (RobotRunnerEvents.STOP_RUN,            self.stop_run),
+        #     (RobotRunnerEvents.POPULATE_RUN_DATA,   self.populate_run_data),
+        #     (RobotRunnerEvents.AFTER_EXPERIMENT,    self.after_experiment)
+        # ])
+        # The subscribe_to_multiple_events has been deprecated. It still works for a matter of compatibility with old projects.
+
+        # New subscription call
+        EventSubscriptionController.subscribe_to_multiple_events_multiple_callbacks([ 
+            (RobotRunnerEvents.BEFORE_EXPERIMENT,   [self.before_experiment_clients, self.before_experiment_local]), # multi callbacks
+            (RobotRunnerEvents.BEFORE_RUN,          [self.before_run]),                                      # single callback
+            (RobotRunnerEvents.START_RUN,           [self.start_run]),
+            (RobotRunnerEvents.START_MEASUREMENT,   [self.start_measurement]),
+            (RobotRunnerEvents.LAUNCH_MISSION,      [self.launch_mission]),
+            (RobotRunnerEvents.STOP_MEASUREMENT,    [self.stop_measurement]),
+            (RobotRunnerEvents.STOP_RUN,            [self.stop_run]),
+            (RobotRunnerEvents.POPULATE_RUN_DATA,   [self.populate_run_data]),
+            (RobotRunnerEvents.AFTER_EXPERIMENT,    [self.after_experiment])                           
         ])
         
         print("Custom config loaded")
@@ -61,8 +78,14 @@ class RobotRunnerConfig:
         run_table.create_experiment_run_table()
         return run_table.get_experiment_run_table()
 
-    def before_experiment(self) -> None:
+    def before_experiment_clients(self) -> None:
         """Perform any activity required before starting the experiment here"""
+
+        print("Config.before_experiment() called!")
+
+    def before_experiment_local(self) -> None:
+        print("Config.before_experiment_local() called!")
+
 
         print("Config.before_experiment() called!")
 

--- a/robot-runner/EventManager/EventSubscriptionController.py
+++ b/robot-runner/EventManager/EventSubscriptionController.py
@@ -2,29 +2,37 @@ from typing import Callable, List, Tuple
 from EventManager.Models.RobotRunnerEvents import RobotRunnerEvents
 
 class EventSubscriptionController:
-    __call_back_register: dict = dict()
+    __call_back_register = dict()
 
     @staticmethod
-    def subscribe_to_single_event(event: RobotRunnerEvents, callback_method: Callable):
-            EventSubscriptionController.__call_back_register[event] = callback_method
+    def subscribe_to_single_event(event: RobotRunnerEvents, callback_methods: List[Callable]):
+            EventSubscriptionController.__call_back_register[event] = callback_methods
 
     @staticmethod
     def subscribe_to_multiple_events(subscriptions: List[Tuple[RobotRunnerEvents, Callable]]):
         for sub in subscriptions:
-            event, callback = sub[0], sub[1]
+            event, callback = sub[0], List[sub[1]]
             EventSubscriptionController.subscribe_to_single_event(event, callback)
 
     @staticmethod
+    def subscribe_to_multiple_events_multiple_callbacks(subscriptions: List[Tuple[RobotRunnerEvents, List[Callable]]]):
+        for sub in subscriptions:
+            event, callbacks = sub[0], sub[1]
+            EventSubscriptionController.subscribe_to_single_event(event, callbacks)
+
+    @staticmethod
     def raise_event(event: RobotRunnerEvents, robot_runner_context = None):
+        event_callbacks = []
         try:
-            event_callback = EventSubscriptionController.__call_back_register[event]
+            event_callbacks = EventSubscriptionController.__call_back_register[event]
         except KeyError:
             return None
 
-        if robot_runner_context:
-            return event_callback(robot_runner_context)
-        else:
-            return event_callback()
+        for event_callback in event_callbacks:
+            if robot_runner_context:
+                event_callback(robot_runner_context)
+            else:
+                event_callback()
 
     @staticmethod
     def get_event_callback(event: RobotRunnerEvents):

--- a/robot-runner/EventManager/EventSubscriptionController.py
+++ b/robot-runner/EventManager/EventSubscriptionController.py
@@ -1,12 +1,18 @@
+from contextlib import suppress
+import inspect
 from typing import Callable, List, Tuple
 from EventManager.Models.RobotRunnerEvents import RobotRunnerEvents
+from ExperimentOrchestrator.Architecture.Distributed.RRWebSocketServer import RRWebSocketServer
+from ConfigValidator.Config.Models.RobotRunnerContext import RobotRunnerContext
 
 class EventSubscriptionController:
     __call_back_register = dict()
+    __remote_call_register = dict()
+    __remote_call_clients_register = dict()
 
     @staticmethod
     def subscribe_to_single_event(event: RobotRunnerEvents, callback_methods: List[Callable]):
-            EventSubscriptionController.__call_back_register[event] = callback_methods
+        EventSubscriptionController.__call_back_register[event] = callback_methods
 
     @staticmethod
     def subscribe_to_multiple_events(subscriptions: List[Tuple[RobotRunnerEvents, Callable]]):
@@ -19,7 +25,17 @@ class EventSubscriptionController:
         for sub in subscriptions:
             event, callbacks = sub[0], sub[1]
             EventSubscriptionController.subscribe_to_single_event(event, callbacks)
-
+                
+    @staticmethod
+    def subscribe_to_multiple_events_multiple_remote_calls(subscriptioins: List[Tuple[RobotRunnerEvents, List[Tuple[str, List[str]]]]]):
+        for sub in subscriptioins:
+            remote_calls = []
+            event, remote_call_tuple = sub[0], sub[1]
+            for remote_call in remote_call_tuple:
+                remote_calls.append(remote_call[0])
+                EventSubscriptionController.__remote_call_clients_register[remote_call[0]] = remote_call[1]
+            EventSubscriptionController.__remote_call_register[event] = remote_calls
+              
     @staticmethod
     def raise_event(event: RobotRunnerEvents, robot_runner_context = None):
         event_callbacks = []
@@ -33,6 +49,24 @@ class EventSubscriptionController:
                 event_callback(robot_runner_context)
             else:
                 event_callback()
+
+    @staticmethod
+    async def raise_remote_event(event: RobotRunnerEvents, server: RRWebSocketServer):
+        event_remote_calls = []
+                
+        try:
+            event_remote_calls = EventSubscriptionController.__remote_call_register[event]
+            print(event_remote_calls)
+        except KeyError:
+            return None
+        
+        for remote_call in event_remote_calls:
+            remote_call_clients = []
+            try:
+                remote_call_clients = EventSubscriptionController.__remote_call_clients_register[remote_call]
+            except KeyError:
+                return None
+            await server.remote_call(remote_call, remote_call_clients)
 
     @staticmethod
     def get_event_callback(event: RobotRunnerEvents):

--- a/robot-runner/ExperimentOrchestrator/Architecture/Distributed/RRWebSocketClient.py
+++ b/robot-runner/ExperimentOrchestrator/Architecture/Distributed/RRWebSocketClient.py
@@ -1,0 +1,39 @@
+import asyncio
+import websockets
+import json
+
+class RRWebSocketClient:
+    def __init__(self, server_address, client_id):
+        self.server_address = server_address
+        self.client_id = client_id
+        self.kill_signal_received = False
+
+    async def register(self):
+        async with websockets.connect(self.server_address) as websocket:
+            registration_data = {
+                "type": "register",
+                "client_id": self.client_id
+            }
+            await websocket.send(json.dumps(registration_data))
+            while not self.kill_signal_received:
+                message = await websocket.recv()
+                data = json.loads(message)
+                if data.get("type") == "kill":
+                    self.kill_signal_received = True
+                    print("Received kill signal. Terminating client.")
+                else:
+                    print(f"Received task: {data}")
+                    ### RECEIVES THE TASK TO BE EXECUTED
+                    ## Call the method received
+
+    # Implement Method CALL
+    
+# Main code
+async def main():
+    server_address = "ws://localhost:8765"
+    client_id = "c1"
+    client = RRWebSocketClient(server_address, client_id)
+    await client.register()
+
+# Run the main coroutine
+asyncio.run(main())

--- a/robot-runner/ExperimentOrchestrator/Architecture/Distributed/RRWebSocketServer.py
+++ b/robot-runner/ExperimentOrchestrator/Architecture/Distributed/RRWebSocketServer.py
@@ -1,0 +1,68 @@
+import asyncio
+import websockets
+import json
+
+class RRWebSocketServer:
+    def __init__(self, host, port):
+        self.host = host
+        self.port = int(port)
+        self.connected_clients = {}
+
+    async def handle_client_message(self, websocket, message):
+        data = json.loads(message)
+        if data.get("type") == "register":
+            client_id = data.get("client_id")
+            if client_id:
+                self.connected_clients[client_id] = websocket
+                print(f"Client {client_id} registered.")
+        elif data.get("type") == "kill":
+            await self.send_kill_signal()
+
+    async def broadcast(self, message):
+        await asyncio.gather(*[client.send(message) for client in self.connected_clients.values()])
+
+    async def send_to_clients(self, message, client_ids):
+        selected_clients = [client for client_id, client in self.connected_clients.items() if client_id in client_ids]
+        await asyncio.gather(*[client.send(message) for client in selected_clients])
+    
+    async def send_kill_signal(self):
+        await self.broadcast(json.dumps({"type": "kill"}))
+
+    async def on_connect(self, websocket, path):
+        try:
+            async for message in websocket:
+                await self.handle_client_message(websocket, message)
+                pass
+        finally:
+            # Ensure the client is removed after disconnect
+            to_remove = []  # Keep track of disconnected clients
+            clients_copy = list(self.connected_clients.items())  # Copy the dictionary items to prevent runtime error
+            for client_id, client_ws in clients_copy:
+                if client_ws == websocket:
+                    to_remove.append(client_id)
+            for client_id in to_remove:
+                self.connected_clients.pop(client_id, None)
+    
+    async def count_connected_clients(self):
+        return len(self.connected_clients)
+    
+    async def start_server(self):
+        server = await websockets.serve(self.on_connect, self.host, self.port)
+        print('RR Server started!')
+        return server
+
+# Main code
+# async def main():
+#     server = RRWebSocketServer("localhost", 8765)
+#     websocket_server = await server.start_server()
+#     count = 0
+#     while True:
+#         # Perform other tasks while the server is running
+#         await asyncio.sleep(1)
+#         if count > 30:
+#             print("Killing clients...")
+#             await server.send_kill_signal()
+#         count += 1
+
+# Run the main coroutine
+# asyncio.run(main())

--- a/robot-runner/ExperimentOrchestrator/Experiment/ExperimentController.py
+++ b/robot-runner/ExperimentOrchestrator/Experiment/ExperimentController.py
@@ -32,6 +32,7 @@ class ExperimentController:
     restarted: bool                = False
     experiment_path_as_string: str = None
     data_manager: CSVOutputManager = None
+    connected_clients: int         = 0
 
     def __init__(self, config: RobotRunnerConfig):
         self.config = config
@@ -51,6 +52,23 @@ class ExperimentController:
         output.console_log_WARNING("Experiment run table created...")
 
     def do_experiment(self):
+        #######################################
+        # Wait for all the clients to connect #
+
+        #### START THE SERVER
+
+        clients = self.config.distributed_clients
+        if clients is not None:
+            output.console_log_OK('Distributed execution.')
+            clients = int(clients)
+            output.console_log_OK(f'Waiting for the {clients} clients to connect!')
+            while self.connected_clients < clients: ### CONECTED_CLIENTS COMES FROM SERVER
+                time.sleep(1)
+        else:
+            output.console_log_OK("Local execution - NO CLIENTS")    
+        ######################################
+
+
         output.console_log_OK("Experiment setup completed...")
         
         # -- Before experiment

--- a/robot-runner/ExperimentOrchestrator/Experiment/Run/IRunController.py
+++ b/robot-runner/ExperimentOrchestrator/Experiment/Run/IRunController.py
@@ -5,6 +5,7 @@ from multiprocessing import Event
 
 from ConfigValidator.Config.RobotRunnerConfig import RobotRunnerConfig
 from ConfigValidator.Config.Models.RobotRunnerContext import RobotRunnerContext
+from ExperimentOrchestrator.Architecture.Distributed.RRWebSocketServer import RRWebSocketServer
 
 class IRunController(ABC):
     run_dir: Path = None
@@ -13,8 +14,9 @@ class IRunController(ABC):
     config: RobotRunnerConfig = None
     run_context: RobotRunnerContext = None
     data_manager: CSVOutputManager = None
+    rr_server: RRWebSocketServer = None
 
-    def __init__(self, variation: tuple, config: RobotRunnerConfig, current_run: int, total_runs: int):
+    def __init__(self, variation: tuple, config: RobotRunnerConfig, current_run: int, total_runs: int, rr_server: RRWebSocketServer):
         self.run_dir = Path(str(config.experiment_path.absolute()) + f"/{variation['__run_id']}")
         self.run_dir.mkdir(parents=True, exist_ok=True)
 
@@ -23,6 +25,8 @@ class IRunController(ABC):
         self.current_run = current_run
         self.run_context = RobotRunnerContext(self.variation, self.current_run, self.run_dir)
         self.data_manager = CSVOutputManager(str(self.config.experiment_path.absolute()))
+
+        self.rr_server = rr_server
 
         self.run_completed_event = Event()
 

--- a/robot-runner/ExperimentOrchestrator/Experiment/Run/RunController.py
+++ b/robot-runner/ExperimentOrchestrator/Experiment/Run/RunController.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from ProgressManager.RunTable.Models.RunProgress import RunProgress
 from EventManager.Models.RobotRunnerEvents import RobotRunnerEvents
 from EventManager.EventSubscriptionController import EventSubscriptionController
@@ -10,22 +12,26 @@ class RunController(IRunController):
     def do_run(self):
         # -- Start run
         output.console_log_WARNING("Calling start_run config hook")
+        asyncio.run(EventSubscriptionController.raise_remote_event(RobotRunnerEvents.START_RUN, self.rr_server))
         EventSubscriptionController.raise_event(RobotRunnerEvents.START_RUN, self.run_context)
 
         # -- Start measurement
         output.console_log_WARNING("... Starting measurement ...")
+        asyncio.run(EventSubscriptionController.raise_remote_event(RobotRunnerEvents.START_MEASUREMENT, self.rr_server))
         EventSubscriptionController.raise_event(RobotRunnerEvents.START_MEASUREMENT, self.run_context)
 
         # -- Start interaction
         output.console_log_WARNING("Calling interaction config hook")
-
+        asyncio.run(EventSubscriptionController.raise_remote_event(RobotRunnerEvents.LAUNCH_MISSION, self.rr_server))
         EventSubscriptionController.raise_event(RobotRunnerEvents.LAUNCH_MISSION, self.run_context)
         output.console_log_OK("... Run completed ...")
 
         # -- Stop measurement
         output.console_log_WARNING("... Stopping measurement ...")
+        asyncio.run(EventSubscriptionController.raise_remote_event(RobotRunnerEvents.STOP_MEASUREMENT, self.rr_server))
         EventSubscriptionController.raise_event(RobotRunnerEvents.STOP_MEASUREMENT, self.run_context)
 
+        asyncio.run(EventSubscriptionController.raise_remote_event(RobotRunnerEvents.POPULATE_RUN_DATA, self.rr_server))
         updated_run_data = EventSubscriptionController.raise_event(RobotRunnerEvents.POPULATE_RUN_DATA, self.run_context)
         if updated_run_data is None:
             row = self.run_context.run_variation
@@ -37,4 +43,5 @@ class RunController(IRunController):
 
         # -- Stop run
         output.console_log_WARNING("Calling stop_run config hook")
+        asyncio.run(EventSubscriptionController.raise_remote_event(RobotRunnerEvents.STOP_RUN, self.rr_server))
         EventSubscriptionController.raise_event(RobotRunnerEvents.STOP_RUN, self.run_context)

--- a/robot-runner/__main__.py
+++ b/robot-runner/__main__.py
@@ -2,6 +2,7 @@ import sys
 import traceback
 from typing import List
 from importlib import util
+import asyncio
 
 from ConfigValidator.CustomErrors.BaseError import BaseError
 from ConfigValidator.CLIRegister.CLIRegister import CLIRegister
@@ -19,7 +20,8 @@ def load_and_get_config_file_as_module(args: List[str]):
     spec.loader.exec_module(config_file)
     return config_file
 
-if __name__ == "__main__":
+#if __name__ == "__main__":
+async def main():
     try: 
         if is_no_argument_given(sys.argv):
             sys.argv.append('help')
@@ -30,7 +32,7 @@ if __name__ == "__main__":
             if hasattr(config_file, 'RobotRunnerConfig'):
                 config = config_file.RobotRunnerConfig()                    # Instantiate config from injected file
                 ConfigValidator.validate_config(config)                     # Validate config as a valid RobotRunnerConfig
-                ExperimentController(config).do_experiment()                # Instantiate controller with config and start experiment
+                await ExperimentController(config).do_experiment()                # Instantiate controller with config and start experiment
             else:
                 raise ConfigInvalidClassNameError
         else:                                                               # Else, a utility command is entered
@@ -39,3 +41,6 @@ if __name__ == "__main__":
         print(f"\n{e}")
     except:                                                                 # All non-covered errors are displayed normally
         traceback.print_exc()
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
This is a simple implementation on top of `WebSockets`. So far, all the remote event subscription is done via local Robot Runner (RR) config file (i.e., the same file used to orchestrate the experiments). In such an approach, the server just notifies the client that it is time to run a method with a specific name. There is no remote method invocation (`RMI`) implemented yet. Despite not being the ideal scenario, it is simple to use, and the WebSocket layers can be useful for further client-server communication.

What is still open:
- Update `README` file with a simple example;
- Update the `RR config file` template.